### PR TITLE
Move assign_unknowns higher up

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -31,7 +31,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,10 +40,8 @@ Imports:
     tibble,
     ggplot2,
     gtools,
-    dbutils,
     survdat
 Remotes:
-    andybeet/dbutils,
     NOAA-EDAB/survdat,
     NEFSC/NEFSC-Spatial
 Config/testthat/edition: 3

--- a/R/check_argument_validation.R
+++ b/R/check_argument_validation.R
@@ -74,18 +74,18 @@ check_argument_validation <- function(aggArea,
 
   # checks for filling in missing values (assign_unknowns)
   # Depending on the flags above will determine how the arguments unkVar and knStrata are defined
-  if (aggArea) {
-    if (!(areaDescription %in% unkVar) | !(areaDescription %in% knStrata)) {
-      stop(paste0("To assign unknowns when using 'aggArea = T', then you need to replace
-           'AREA' with '" ,areaDescription,"' in both 'unkVar' and 'knStrata' arguments"))
-    }
-  } else {
-    if (!("AREA" %in% unkVar) | !("AREA" %in% knStrata)) {
-      stop(paste0("To assign unknowns when using 'aggArea = F', then you need to use
-           'AREA' in both 'unkVar' and 'knStrata' arguments"))
-    }
-
-  }
+  # if (aggArea) {
+  #   if (!(areaDescription %in% unkVar) | !(areaDescription %in% knStrata)) {
+  #     stop(paste0("To assign unknowns when using 'aggArea = T', then you need to replace
+  #          'AREA' with '" ,areaDescription,"' in both 'unkVar' and 'knStrata' arguments"))
+  #   }
+  # } else {
+  #   if (!("AREA" %in% unkVar) | !("AREA" %in% knStrata)) {
+  #     stop(paste0("To assign unknowns when using 'aggArea = F', then you need to use
+  #          'AREA' in both 'unkVar' and 'knStrata' arguments"))
+  #   }
+  #
+  # }
 
   if (aggGear) {
     if (!(fleetDescription %in% unkVar) | !(fleetDescription %in% knStrata)) {

--- a/R/check_argument_validation.R
+++ b/R/check_argument_validation.R
@@ -87,17 +87,17 @@ check_argument_validation <- function(aggArea,
   #
   # }
 
-  if (aggGear) {
-    if (!(fleetDescription %in% unkVar) | !(fleetDescription %in% knStrata)) {
-      stop(paste0("To assign unknowns when using 'aggGear = T', then you need to replace
-                'NEGEAR' with '" ,fleetDescription,"' in both 'unkVar' and 'knStrata' arguments"))
-    }
-  } else {
-    if (!("NEGEAR" %in% unkVar) | !("NEGEAR" %in% knStrata)) {
-      stop(paste0("To assign unknowns when using 'aggGear = F', then you need to use
-           'NEGEAR' in both 'unkVar' and 'knStrata' arguments"))
-    }
-  }
+  # if (aggGear) {
+  #   if (!(fleetDescription %in% unkVar) | !(fleetDescription %in% knStrata)) {
+  #     stop(paste0("To assign unknowns when using 'aggGear = T', then you need to replace
+  #               'NEGEAR' with '" ,fleetDescription,"' in both 'unkVar' and 'knStrata' arguments"))
+  #   }
+  # } else {
+  #   if (!("NEGEAR" %in% unkVar) | !("NEGEAR" %in% knStrata)) {
+  #     stop(paste0("To assign unknowns when using 'aggGear = F', then you need to use
+  #          'NEGEAR' in both 'unkVar' and 'knStrata' arguments"))
+  #   }
+  # }
 
 
 

--- a/R/get_comland_data.R
+++ b/R/get_comland_data.R
@@ -89,10 +89,10 @@ get_comland_data <- function(channel,
                              knStrata = c('HY', 'QY','MONTH','NEGEAR', 'TONCL2', 'AREA')) {
 
 
-
+  # saves initial the function call and returns it with the data pull
   call <- dbutils::capture_function_call()
 
-
+  # checks to make sure argument values are aligned
   check_argument_validation(aggArea,
                             userAreas,
                             areaDescription,
@@ -110,6 +110,10 @@ get_comland_data <- function(channel,
   comland <- comlandr::get_comland_raw_data(channel,
                                             filterByYear, filterByArea,
                                             useLanded, removeParts)
+
+  #Impute unknown catch variables
+  if(!is.null(unkVar)) comland <- assign_unknown(comland, unkVar, knStrata)
+
 
   #Pull herring data from the state of Maine
   if(useHerringMaine){
@@ -162,9 +166,6 @@ get_comland_data <- function(channel,
 
   #Aggregate gears
   if(aggGear) comland <- aggregate_gear(comland, userGears, fleetDescription)
-
-  #Impute unknown catch variables
-  if(!is.null(unkVar)) comland <- assign_unknown(comland, unkVar, knStrata)
 
   comland$call <- call
 


### PR DESCRIPTION
## Updates

* Moved the `assign_unknowns` function higher up the order of operations in `get_comland_data`. Now operates on raw data then allows user to aggregate by fleet/area AFTER unknowns are "imputed". Rather than allowing the user to aggregate data then assign unknowns based on aggregated data. This makes more sense and reduces the need to change arguments in `unkVar` and `knStrata` to match aggregation choice.

* Changed `get_comdisc_data.r` function to work with change in `aggregate_area` flags (`applyProps`)

* `check_argument_validation` function changes based on above

**NOTE: All SOE indicators have been calculated based on this change (`comdat`,`bennet`) - minimal differences. Haven't looked to see if this resolves the shellfish issue seen in the 2024 report (missing AREA/EPU being assigned to wrong EPU)**