### PR TITLE
fix cfdbs to point to nefsc_garfo

### DIFF
--- a/R/get_areas.R
+++ b/R/get_areas.R
@@ -53,7 +53,7 @@ get_areas <- function(channel,areas="all"){
   query <- DBI::dbGetQuery(channel,sqlStatement)
 
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'AREA' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_AREA' and owner='NEFSC_GARFO'"
   colNames <- t(DBI::dbGetQuery(channel,sqlcolName))
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_areas.R
+++ b/R/get_areas.R
@@ -15,7 +15,7 @@
 #'
 #'    \item{colNames}{ a vector of the table's column names}
 #'
-#'The default sql statement "\code{select * from cfdbs.area}" is used
+#'The default sql statement "\code{select * from NEFSC_GARFO.cfdbs_area}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations
@@ -48,7 +48,7 @@
 get_areas <- function(channel,areas="all"){
 
 
-  sqlStatement <- dbutils::create_sql(areas,fieldName="area",fieldName2="areanm",dataType="%03d",defaultSqlStatement="select * from cfdbs.area")
+  sqlStatement <- dbutils::create_sql(areas,fieldName="area",fieldName2="areanm",dataType="%03d",defaultSqlStatement="select * from NEFSC_GARFO.cfdbs_area")
 
   query <- DBI::dbGetQuery(channel,sqlStatement)
 

--- a/R/get_gears.R
+++ b/R/get_gears.R
@@ -52,7 +52,7 @@ get_gears <- function(channel,gears="all") {
   query <- DBI::dbGetQuery(channel,sqlStatement)
 
 # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'GEAR' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_GEAR' and owner='NEFSC_GARFO'"
   colNames <- DBI::dbGetQuery(channel,sqlcolName)
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_gears.R
+++ b/R/get_gears.R
@@ -16,7 +16,7 @@
 #'
 #'   \item{colNames}{a vector of the table's column names}
 #'
-#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.gear}" is used
+#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_gear}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations
@@ -47,13 +47,7 @@
 #
 get_gears <- function(channel,gears="all") {
 
-  #appends where
-#  if (!is.null(where)) {
-#    sqlStatement <- paste(sqlStatement,"where",where,";")
-#  }
-
-  sqlStatement <- dbutils::create_sql(gears,fieldName="negear2",fieldName2="gearnm",dataType="%02d",defaultSqlStatement="select * from cfdbs.gear")
-
+  sqlStatement <- dbutils::create_sql(gears,fieldName="negear2",fieldName2="gearnm",dataType="%02d",defaultSqlStatement="select * from NEFSC_GARFO.cfdbs_gear")
 
   query <- DBI::dbGetQuery(channel,sqlStatement)
 

--- a/R/get_locations.R
+++ b/R/get_locations.R
@@ -38,7 +38,7 @@ get_locations <- function(channel){
   query <- DBI::dbGetQuery(channel,sqlStatement)
 
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'LOC' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_LOC' and owner='NEFSC_GARFO'"
   colNames <- DBI::dbGetQuery(channel,sqlcolName)
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_locations.R
+++ b/R/get_locations.R
@@ -3,11 +3,7 @@
 #'Extract a list of lat, long, ten minute square, etc from the NEFSC "loc" supporting table
 #'
 #'
-#'
 #' @inheritParams get_comland_data
-#' @param sqlStatement Character string. An sql statement (optional).
-#' If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.loc}" is used
-#'
 #'
 #' @return A list is returned:
 #'
@@ -30,27 +26,16 @@
 #' # extracts complete locations table based on default sql statement
 #' channel <- connect_to_database(server="name_of_server",uid="individuals_username")
 #' get_locations(channel)
-#'
-#' # extracts subset of location information. Statistical area, and 10 minute square based
-#' # on custom sql statement
-#' sqlStatement <- "select area TENMSQ from cfdbs.loc;"
-#' get_locations(channel,sqlStatement)
-#'
-#' # extracts 10 minute square info for an area on geaorges bank (511) based on custom sql statement
-#' sqlStatement <- "select area, tenmsq  from cfdbs.loc where area=511;"
-#' get_locations(channel,sqlStatement)
 #'}
 #'
 #' @export
 #'
 #
-get_locations <- function(channel,sqlStatement="select * from cfdbs.loc"){
+get_locations <- function(channel){
+
+  sqlStatement <- "select * from NEFSC_GARFO.cfdbs_loc"
 
   query <- DBI::dbGetQuery(channel,sqlStatement)
-
-  #data <- query[order(query$AREA),]
-
-  #save(species,file="data/speciesDefinitions.RData")
 
   # get column names
   sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'LOC' and owner='CFDBS'"

--- a/R/get_ports.R
+++ b/R/get_ports.R
@@ -14,7 +14,7 @@
 #'
 #'   \item{colNames}{a vector of the table's column names}
 #'
-#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.port}" is used
+#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_port}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations
@@ -47,7 +47,7 @@
 get_ports <- function(channel,ports="all"){
 
   # creates the sql based on user input
-  sqlStatement <- dbutils::create_sql(ports,fieldName="port",fieldName2="portnm",dataType="%06d",defaultSqlStatement="select * from cfdbs.port")
+  sqlStatement <- dbutils::create_sql(ports,fieldName="port",fieldName2="portnm",dataType="%06d",defaultSqlStatement="select * from NEFSC_GARFO.cfdbs_port")
 
   query <- DBI::dbGetQuery(channel,sqlStatement)
 

--- a/R/get_ports.R
+++ b/R/get_ports.R
@@ -55,7 +55,7 @@ get_ports <- function(channel,ports="all"){
 
   #save(species,file="data/speciesDefinitions.RData")
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'PORT' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_PORT' and owner='NEFSC_GARFO'"
   colNames <- t(DBI::dbGetQuery(channel,sqlcolName))
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_species.R
+++ b/R/get_species.R
@@ -16,7 +16,7 @@
 #'
 #'   \item{colNames}{a vector of the table's column names}
 #'
-#'The default sql statement "\code{select * from cfdbs.cfspp}" is used
+#'The default sql statement "\code{select * from NEFSC_GARFO.cfdbs_cfspp}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations.
@@ -53,7 +53,7 @@
 get_species <- function(channel,species="all"){
 
   # creates the sql based on user input
-  sqlStatement <- dbutils::create_sql(species,fieldName="nespp3",fieldName2="sppnm",dataType="%03d",defaultSqlStatement="select * from cfdbs.cfspp")
+  sqlStatement <- dbutils::create_sql(species,fieldName="nespp3",fieldName2="sppnm",dataType="%03d",defaultSqlStatement="select * from NEFSC_GARFO.cfdbs_cfspp")
 
   query <- DBI::dbGetQuery(channel,sqlStatement)
 

--- a/R/get_species.R
+++ b/R/get_species.R
@@ -58,7 +58,7 @@ get_species <- function(channel,species="all"){
   query <- DBI::dbGetQuery(channel,sqlStatement)
 
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFSPP' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_CFSPP' and owner='NEFSC_GARFO'"
   colNames <- t(DBI::dbGetQuery(channel,sqlcolName))
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_species_itis.R
+++ b/R/get_species_itis.R
@@ -17,7 +17,7 @@
 #'
 #'   \item{colNames}{a vector of the table's column names}
 #'
-#'The default sql statement "\code{select * from cfdbs.SPECIES_ITIS_NE}" is used
+#'The default sql statement "\code{select * from NEFSC_GARFO.cfdbs_SPECIES_ITIS_NE}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations.

--- a/R/get_species_itis.R
+++ b/R/get_species_itis.R
@@ -85,7 +85,7 @@ get_species_itis <- function(channel,species="all",nameType="common_name"){
   query <- DBI::dbGetQuery(channel,sqlStatement)
 
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'SPECIES_ITIS_NE' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_SPECIES_ITIS_NE' and owner='NEFSC_GARFO'"
   colNames <- t(DBI::dbGetQuery(channel,sqlcolName))
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_vessels.R
+++ b/R/get_vessels.R
@@ -42,7 +42,7 @@ get_vessels <- function(channel){
   query <- DBI::dbGetQuery(channel,sqlStatement)
 
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'MSTRVESS' and owner='CFDBS'"
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_MSTRVESS' and owner='NEFSC_GARFO'"
   colNames <- DBI::dbGetQuery(channel,sqlcolName)
 
   return (list(data=dplyr::as_tibble(query),sql=sqlStatement, colNames=colNames))

--- a/R/get_vessels.R
+++ b/R/get_vessels.R
@@ -15,7 +15,7 @@
 #'
 #'  \item{colNames}{a vector of the table's column names}
 #'
-#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.mstrvess}" is used
+#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_mstrvess}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations
@@ -30,30 +30,16 @@
 #' channel <- connect_to_database(server="name_of_server",uid="individuals_username")
 #' get_vessels(channel)
 #'
-#' # extracts vessel ID, crew size, and home port on custom sql statement
-#' sqlStatement <- "select vessel, crew, homeport from cfdbs.mstrvess;"
-#' get_vessels(channel,sqlStatement)
-#'
-#' # extracts all vessel info for vessels lengths < 50ft based on custom sql statement
-#' sqlStatement <- "select * from cfdbs.mstrvess where vesslen <29;"
-#' get_vessels(channel,sqlStatement)
 #'}
 #'
 #' @export
 #'
 #
-get_vessels <- function(channel,sqlStatement="select * from cfdbs.mstrvess",where=NULL){
+get_vessels <- function(channel){
 
-  #appends where
-  if (!is.null(where)) {
-    sqlStatement <- paste(sqlStatement,"where",where)
-  }
+  sqlStatement <- "select * from NEFSC_GARFO.cfdbs_mstrvess"
 
   query <- DBI::dbGetQuery(channel,sqlStatement)
-
-  #data <- query[order(query$VESSEL),]
-
-  #save(species,file="data/speciesDefinitions.RData")
 
   # get column names
   sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'MSTRVESS' and owner='CFDBS'"

--- a/R/process_foreign_data.R
+++ b/R/process_foreign_data.R
@@ -79,7 +79,7 @@ process_foreign_data <- function(channel, nafoland, useLanded = T, useHerringMai
                        c('Year', 'GearCode', 'Tonnage', 'Code', 'Divcode'),
                        c('YEAR', 'NAFOGEAR', 'TONCL1', 'NAFOSPP', 'AREA'))
 
-  spp <- data.table::as.data.table(DBI::dbGetQuery(channel, "select NAFOSPP, NESPP3 from cfdbs.CFSPP"))
+  spp <- data.table::as.data.table(DBI::dbGetQuery(channel, "select NAFOSPP, NESPP3 from NEFSC_GARFO.cfdbs_CFSPP"))
   spp$NAFOSPP <- as.integer(spp$NAFOSPP)
   spp$NESPP3 <- as.integer(spp$NESPP3)
 
@@ -122,7 +122,7 @@ process_foreign_data <- function(channel, nafoland, useLanded = T, useHerringMai
 
   #Gearcodes
 
-  gear <- data.table::as.data.table(DBI::dbGetQuery(channel, "select NEGEAR, NAFOGEAR from cfdbs.Gear"))
+  gear <- data.table::as.data.table(DBI::dbGetQuery(channel, "select NEGEAR, NAFOGEAR from NEFSC_GARFO.cfdbs_Gear"))
   gear$NEGEAR <- as.integer(gear$NEGEAR)
   gear$NAFOGEAR <- as.integer(gear$NAFOGEAR)
 

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -17,7 +17,7 @@ articles:
   Overview: Overview.html
   schemas: schemas.html
   speciesValue: speciesValue.html
-last_built: 2025-03-21T20:40Z
+last_built: 2025-04-03T18:24Z
 urls:
   reference: https://noaa-edab.github.io/comlandr/reference
   article: https://noaa-edab.github.io/comlandr/articles

--- a/man/get_areas.Rd
+++ b/man/get_areas.Rd
@@ -22,7 +22,7 @@ A list is returned:
 
 \item{colNames}{ a vector of the table's column names}
 
-The default sql statement "\code{select * from cfdbs.area}" is used
+The default sql statement "\code{select * from NEFSC_GARFO.cfdbs_area}" is used
 }
 \description{
 Extract a list of statistical areas, region, NAFO codes, etc from the NEFSC "Area" supporting table

--- a/man/get_gears.Rd
+++ b/man/get_gears.Rd
@@ -22,7 +22,7 @@ A list is returned:
 
 \item{colNames}{a vector of the table's column names}
 
-If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.gear}" is used
+If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_gear}" is used
 }
 \description{
 Extract a list of gear types in the NEFSC "GEAR" supporting table

--- a/man/get_locations.Rd
+++ b/man/get_locations.Rd
@@ -4,14 +4,11 @@
 \alias{get_locations}
 \title{Extract LOCATION information from CFDBS}
 \usage{
-get_locations(channel, sqlStatement = "select * from cfdbs.loc")
+get_locations(channel)
 }
 \arguments{
 \item{channel}{an Object inherited from \code{ROracle::Oracle}. This object is used to connect
 to communicate with the database engine. (see \code{dbutils::connect_to_database})}
-
-\item{sqlStatement}{Character string. An sql statement (optional).
-If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.loc}" is used}
 }
 \value{
 A list is returned:
@@ -35,15 +32,6 @@ Use the data dictionary for field name explanations
 # extracts complete locations table based on default sql statement
 channel <- connect_to_database(server="name_of_server",uid="individuals_username")
 get_locations(channel)
-
-# extracts subset of location information. Statistical area, and 10 minute square based
-# on custom sql statement
-sqlStatement <- "select area TENMSQ from cfdbs.loc;"
-get_locations(channel,sqlStatement)
-
-# extracts 10 minute square info for an area on geaorges bank (511) based on custom sql statement
-sqlStatement <- "select area, tenmsq  from cfdbs.loc where area=511;"
-get_locations(channel,sqlStatement)
 }
 
 }

--- a/man/get_ports.Rd
+++ b/man/get_ports.Rd
@@ -22,7 +22,7 @@ A list is returned:
 
 \item{colNames}{a vector of the table's column names}
 
-If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.port}" is used
+If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_port}" is used
 }
 \description{
 Extract a list of port names, and location info for vessel landings from the NEFSC "Port" supporting table

--- a/man/get_species.Rd
+++ b/man/get_species.Rd
@@ -23,7 +23,7 @@ A list is returned:
 
 \item{colNames}{a vector of the table's column names}
 
-The default sql statement "\code{select * from cfdbs.cfspp}" is used
+The default sql statement "\code{select * from NEFSC_GARFO.cfdbs_cfspp}" is used
 }
 \description{
 Extract a list of speices names, code, market category, etc from the NEFSC cfspp table

--- a/man/get_species_itis.Rd
+++ b/man/get_species_itis.Rd
@@ -25,7 +25,7 @@ A list is returned:
 
 \item{colNames}{a vector of the table's column names}
 
-The default sql statement "\code{select * from cfdbs.SPECIES_ITIS_NE}" is used
+The default sql statement "\code{select * from NEFSC_GARFO.cfdbs_SPECIES_ITIS_NE}" is used
 }
 \description{
 Extract a list of species names, code, market category, etc from the NEFSC_GARFO CFDBS_SPECIES_ITIS_NE table

--- a/man/get_vessels.Rd
+++ b/man/get_vessels.Rd
@@ -4,11 +4,7 @@
 \alias{get_vessels}
 \title{Extract VESSEL information from CFDBS}
 \usage{
-get_vessels(
-  channel,
-  sqlStatement = "select * from cfdbs.mstrvess",
-  where = NULL
-)
+get_vessels(channel)
 }
 \arguments{
 \item{channel}{an Object inherited from \code{ROracle::Oracle}. This object is used to connect
@@ -27,7 +23,7 @@ A list is returned:
 
 \item{colNames}{a vector of the table's column names}
 
-If no \code{sqlStatement} is provided the default sql statement "\code{select * from cfdbs.mstrvess}" is used
+If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_mstrvess}" is used
 }
 \description{
 Extract a list of vessell ID's, tonnage, crew size, home port, etc from the NEFSC "Mstrvess" supporting table
@@ -43,13 +39,6 @@ Use the data dictionary for field name explanations
 channel <- connect_to_database(server="name_of_server",uid="individuals_username")
 get_vessels(channel)
 
-# extracts vessel ID, crew size, and home port on custom sql statement
-sqlStatement <- "select vessel, crew, homeport from cfdbs.mstrvess;"
-get_vessels(channel,sqlStatement)
-
-# extracts all vessel info for vessels lengths < 50ft based on custom sql statement
-sqlStatement <- "select * from cfdbs.mstrvess where vesslen <29;"
-get_vessels(channel,sqlStatement)
 }
 
 }

--- a/vignettes/comlandr.Rmd
+++ b/vignettes/comlandr.Rmd
@@ -22,7 +22,7 @@ library(comlandr)
 
 * You will need to have `ROracle` installed and configured on your machine.
 * While it is certainly possible to define your own connection to the database it is much easier using the package [`dbutils`](https://github.com/andybeet/dbutils).
-* Permissions to the `STOCKEFF` schema
+* Permissions to several schemas eg. `STOCKEFF`. See `vignette("schemas")` for more details.
 
 ## Connect to the database
 

--- a/vignettes/schemas.Rmd
+++ b/vignettes/schemas.Rmd
@@ -19,11 +19,10 @@ To use comlandr, you will need permissions to access several databases. The foll
 
 ```{r table, echo = F, eval = T}
 sample_list <- list(
-  cfdbs = c("area", "gear", "loc", "port", "cfspp", "species_itis_ne", "mstrvess"),
   svdbs = c("survan_conversion_factors", "svcruise_purpose", "length_weight_coefficients", "union_fscs_svbio", "union_fscs_svsta", "union_fscs_svcat", "union_fscs_svlen", "svdbs_cruises", "fscs_maturity_codes", "sex_codes","fscs_sex_codes", "svspecies_list", "svmstrata", "sv_vessel", "mstr_cruise"),
   stockeff = c("mv_cf_landings"),
   obdbs = c("obspp", "asmpp", "obinc", "obotgh", "obspecconv", "obspec"),
-  NEFSC_GARFO = c("maine_herring_catch"))
+  NEFSC_GARFO = c("maine_herring_catch","area", "gear", "loc", "port", "cfspp", "species_itis_ne", "mstrvess"))
 
 max_len <- max(lengths(sample_list))
 


### PR DESCRIPTION
## Minor

cfdbs schema has bee moved to NEFSC_GARFO. All references to tables in cfdbs need to be changed
eg. cfdbs.gear - > NEFSC_GARFO.cfdbs_gear

* all helper `get_` functions needed changes
* rmds updated to reflect user no longer needs access to cfdbs