### PR TITLE
Fix/i39 suppress NA warning

### DIFF
--- a/R/get_comland_raw_data.R
+++ b/R/get_comland_raw_data.R
@@ -146,7 +146,11 @@ get_comland_raw_data <- function(
     'UTILCD',
     'AREA'
   )
-  comland[, (numberCols) := lapply(.SD, as.numeric), .SDcols = numberCols][]
+  # Note AREA has non numeric values "OFF" and "OFR" (State data). These will be converted to NA
+  comland[,
+    (numberCols) := lapply(.SD, function(x) suppressWarnings(as.numeric(x))),
+    .SDcols = numberCols
+  ][]
 
   #Adjust pounds to metric tons
   comland[, SPPLIVMT := SPPLIVLB * 0.00045359237]

--- a/R/get_herring_data.R
+++ b/R/get_herring_data.R
@@ -51,7 +51,7 @@ get_herring_data <- function(
   herr_catch <- DBI::dbGetQuery(channel, herr_qry) |>
     dplyr::as_tibble()
 
-  # Convert number fields from characterr to numeric
+  # Convert number fields from character to numeric
   herr_catch <- herr_catch |>
     dplyr::mutate(
       YEAR = as.numeric(YEAR),


### PR DESCRIPTION
## Reason

The data pull was creating an annoying warning message "NAs introduced by coercion". Originally thought to be in `get_herring_data`. The warnign was coming from `get_comland_raw_data` when trying to convert AREA from character to numeric. There are two entries "OFF", "OFR" causing the problem.

Fixes Issue #39 

## Style

Added the air toml file that was supposed to have been included in an earlier PR #111 

## To review

No review needed. Single line fix