### PR TITLE
build(#122): changes due to Node.js 20 deprecation

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/getFred.yaml
+++ b/.github/workflows/getFred.yaml
@@ -82,7 +82,7 @@ jobs:
           subject: Github Actions job result
           to: andrew.beet@noaa.gov
 
-          from: 'comlandr FRED update <noreply@gmail.com>'
+          from: "comlandr FRED update <noreply@gmail.com>"
           envelope_from: ${{ secrets.AB_MAIL_USERNAME }}
 
           #body: file://${{github.workspace}}/data-raw/datapull.txt

--- a/.github/workflows/getFred.yaml
+++ b/.github/workflows/getFred.yaml
@@ -82,7 +82,7 @@ jobs:
           subject: Github Actions job result
           to: andrew.beet@noaa.gov
 
-          from: "comlandr FRED update <noreply@gmail.com>"
+          from: 'comlandr FRED update <noreply@gmail.com>'
           envelope_from: ${{ secrets.AB_MAIL_USERNAME }}
 
           #body: file://${{github.workspace}}/data-raw/datapull.txt

--- a/.github/workflows/getFred.yaml
+++ b/.github/workflows/getFred.yaml
@@ -81,7 +81,7 @@ jobs:
           subject: Github Actions job result
           to: andrew.beet@noaa.gov
 
-          from: comlandr FRED update
+          from: 'comlandr FRED update'
 
           #body: file://${{github.workspace}}/data-raw/datapull.txt
 

--- a/.github/workflows/getFred.yaml
+++ b/.github/workflows/getFred.yaml
@@ -12,6 +12,7 @@ on:
   schedule:
     # uses UTC/GMT time (+ 5 hrs)
     - cron: "0 0 20 * *" # Every Month (Day 20) at 0000 hrs = 0500 UTC. WPU0223 updates on 16th
+  workflow_dispatch:
 
 jobs:
 
@@ -23,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -81,7 +82,8 @@ jobs:
           subject: Github Actions job result
           to: andrew.beet@noaa.gov
 
-          from: 'comlandr FRED update'
+          from: 'comlandr FRED update <noreply@gmail.com>'
+          envelope_from: ${{ secrets.AB_MAIL_USERNAME }}
 
           #body: file://${{github.workspace}}/data-raw/datapull.txt
 

--- a/.github/workflows/getFred.yaml
+++ b/.github/workflows/getFred.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
 
       # Send email indicating if anything has changed
       - name: Send email
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v13
 
         with:
           server_address: smtp.gmail.com

--- a/.github/workflows/getFred.yaml
+++ b/.github/workflows/getFred.yaml
@@ -70,7 +70,7 @@ jobs:
 
       # Send email indicating if anything has changed
       - name: Send email
-        uses: dawidd6/action-send-mail@v13
+        uses: dawidd6/action-send-mail@v14
 
         with:
           server_address: smtp.gmail.com

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           clean: false
           branch: gh-pages


### PR DESCRIPTION
## Justification

Node.js 20 actions are deprecated. Actions need to be updated to versions that use Node.js 24

r-lib/actions use a sliding tag not an immutable tag. Update has been made. No changes needed for v2

fixes #122 

## Versioning

None of the changes require a versioning of the package

## Reviewers

Nothing to be done. Automated workflow pass/failure will be the test