### PR TITLE
Fix(#95): Pull vessel data from alternative source

### DIFF
--- a/R/get_dealers.R
+++ b/R/get_dealers.R
@@ -44,7 +44,7 @@
 #
 get_dealers <- function(channel, state = NA, year = NA) {
   # creates the sql based on user input
-  defaultSqlStatement = "select * from NEFSC_GARFO.PERMIT_DEALER"
+  defaultSqlStatement <- "select * from NEFSC_GARFO.PERMIT_DEALER"
   if (all(any(is.na(state)) & any(is.na(year)))) {
     # both are NA
     sqlStatement <- defaultSqlStatement

--- a/R/get_vessels.R
+++ b/R/get_vessels.R
@@ -1,6 +1,6 @@
-#' Extract VESSEL information from CFDBS
+#' Extract VESSEL information
 #'
-#'Extract a list of vessell ID's, tonnage, crew size, home port, etc from the NEFSC "Mstrvess" supporting table
+#'Extract a list of vessel ID's, tonnage, crew size, home port, etc from the NEFSC_GARFO "PERMIT_VPS_VESSEL" supporting table
 #'
 #'
 #' @inheritParams get_comland_data
@@ -12,8 +12,6 @@
 #'   \item{sql}{containing the \code{sqlStatement} itself}
 #'
 #'  \item{colNames}{a vector of the table's column names}
-#'
-#'If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_mstrvess}" is used
 #'
 #'@section Reference:
 #'Use the data dictionary for field name explanations
@@ -34,13 +32,15 @@
 #'
 #
 get_vessels <- function(channel) {
-  sqlStatement <- "select * from NEFSC_GARFO.cfdbs_mstrvess"
+  #sqlStatement <- "select * from NEFSC_GARFO.PERMIT_VPS_VESSEL"
+  message("Pulling the vessel data ...")
+  # Select set of fields
+  sqlStatement <- "select VES_NAME, HPORT, HPST, PPORT, PPST, ZIP1, LEN, CREW, GTONS, VHP, BLT, DATE_ISSUED, DATE_CANCELED from NEFSC_GARFO.PERMIT_VPS_VESSEL"
 
   query <- DBI::dbGetQuery(channel, sqlStatement)
-
   # get column names
-  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'CFDBS_MSTRVESS' and owner='NEFSC_GARFO'"
-  colNames <- DBI::dbGetQuery(channel, sqlcolName)
+  sqlcolName <- "select COLUMN_NAME from ALL_TAB_COLUMNS where TABLE_NAME = 'PERMIT_VPS_VESSEL' and owner='NEFSC_GARFO'"
+  colNames <- t(DBI::dbGetQuery(channel, sqlcolName))
 
   return(list(
     data = dplyr::as_tibble(query),

--- a/man/get_vessels.Rd
+++ b/man/get_vessels.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/get_vessels.R
 \name{get_vessels}
 \alias{get_vessels}
-\title{Extract VESSEL information from CFDBS}
+\title{Extract VESSEL information}
 \usage{
 get_vessels(channel)
 }
@@ -18,11 +18,9 @@ A list is returned:
 \item{sql}{containing the \code{sqlStatement} itself}
 
 \item{colNames}{a vector of the table's column names}
-
-If no \code{sqlStatement} is provided the default sql statement "\code{select * from NEFSC_GARFO.cfdbs_mstrvess}" is used
 }
 \description{
-Extract a list of vessell ID's, tonnage, crew size, home port, etc from the NEFSC "Mstrvess" supporting table
+Extract a list of vessel ID's, tonnage, crew size, home port, etc from the NEFSC_GARFO "PERMIT_VPS_VESSEL" supporting table
 }
 \section{Reference}{
 


### PR DESCRIPTION
### Justification

The  `get_vessels()` function didn't function correctly because of a special character in the underlying data. In addition the table it was pulling from was dated. The table now being pulled from is a valid/equivalent table.

Fixes #95 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)


### Reviewer instructions

Assign at least 2 reviewers: 
* one of which should be a maintainer of this repo, 
* the others should be familiar with the subject or problem.

Please build the package from this branch, connect to the database, and then run the function `get_vessels(channel)`. A list of 2 items should be returned in the same format and the other `get_` functions. Check the docs for readability/spelling by either `pkgdown::build_site()` or `?get_vessels`

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
