### PR TITLE
Fix(#39): remove NAs before type casting

### DIFF
--- a/R/get_herring_data.R
+++ b/R/get_herring_data.R
@@ -53,6 +53,9 @@ get_herring_data <- function(
 
   # Convert number fields from character to numeric
   herr_catch <- herr_catch |>
+    dplyr::filter(
+      !is.na(suppressWarnings(as.numeric(STOCK_AREA))) & !is.na(STOCK_AREA)
+    ) |>
     dplyr::mutate(
       YEAR = as.numeric(YEAR),
       MONTH = as.numeric(MONTH),


### PR DESCRIPTION
### Justification

This issue was previously fixed but it appears the database has introduced additional data issues. Several STOCK_AREA values are either NAs or "NA". This warnings causes GitHub workflows to fail (although we could prevent workflows from failing on a warning, i'd prefere to fix the code). These NAs have been filtered out prior to type casting to numeric. Issue 39 was reopened. 

Fixes #39

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

Do the following on `dev` and this branch.
* Connect to the database eg. `channel <- dbutils::connect_to_database("server", "user")`
* `get_herring_data(channel)`
The coercion warning should be fixed

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
